### PR TITLE
Add simple mock class

### DIFF
--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/class/expect.toReturn..st
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/class/expect.toReturn..st
@@ -1,0 +1,4 @@
+mocking
+expect: aSymbol toReturn: anObject
+
+	^ self new expect: aSymbol withArguments: nil toReturn: anObject

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/class/expect.withArgument.toReturn..st
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/class/expect.withArgument.toReturn..st
@@ -1,0 +1,4 @@
+mocking
+expect: aSymbol withArgument: anArgumentObject toReturn: aReturnObject
+
+	^ self new expect: aSymbol withArguments: { anArgumentObject } toReturn: aReturnObject

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/class/expect.withArguments.toReturn..st
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/class/expect.withArguments.toReturn..st
@@ -1,0 +1,4 @@
+mocking
+expect: aSymbol withArguments: anArray toReturn: anObject
+
+	^ self new expect: aSymbol withArguments: anArray toReturn: anObject

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/doesNotUnderstand..st
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/doesNotUnderstand..st
@@ -1,0 +1,9 @@
+error handling
+doesNotUnderstand: aMessage
+	
+	| match |
+	
+	match := self expectations select: [ :expectation | expectation matches: aMessage ].
+	match ifEmpty: [ super doesNotUnderstand: aMessage ].
+	
+	^ match asArray first returnValue.

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/expect.toReturn..st
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/expect.toReturn..st
@@ -1,0 +1,4 @@
+mocking
+expect: aMessage toReturn: anObject
+
+	self expect: aMessage withArguments: nil toReturn: anObject

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/expect.withArgument.toReturn..st
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/expect.withArgument.toReturn..st
@@ -1,0 +1,4 @@
+mocking
+expect: aSymbol withArgument: anArgumentObject toReturn: aReturnObject
+	
+	self expect:  aSymbol withArguments: { anArgumentObject } toReturn: aReturnObject.

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/expect.withArguments.toReturn..st
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/expect.withArguments.toReturn..st
@@ -1,0 +1,11 @@
+mocking
+expect: aSymbol withArguments: anArray toReturn: anObject
+
+	| expectation |
+	
+	expectation := MockExpectation new
+		selector: aSymbol;
+		arguments: anArray;
+		returnValue: anObject.
+		
+	self expectations add: expectation

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/expectations..st
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/expectations..st
@@ -1,0 +1,4 @@
+accessing
+expectations: anObject
+
+	expectations := anObject

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/expectations.st
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/expectations.st
@@ -1,0 +1,4 @@
+accessing
+expectations
+
+	^ expectations

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/initialize.st
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/instance/initialize.st
@@ -1,0 +1,5 @@
+initialization
+initialize
+
+	super initialize.
+	self expectations: Set new

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/methodProperties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/methodProperties.json
@@ -1,0 +1,11 @@
+{
+	"class" : {
+		"expect:toReturn:" : "TP 7/8/2019 22:41",
+		"expect:withArguments:toReturn:" : "TP 7/8/2019 22:41" },
+	"instance" : {
+		"doesNotUnderstand:" : "TP 7/9/2019 00:00",
+		"expect:toReturn:" : "TP 7/8/2019 22:41",
+		"expect:withArguments:toReturn:" : "TP 7/9/2019 00:58",
+		"expectations" : "TP 7/8/2019 22:14",
+		"expectations:" : "TP 7/8/2019 22:14",
+		"initialize" : "TP 7/9/2019 00:50" } }

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/methodProperties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/methodProperties.json
@@ -1,10 +1,12 @@
 {
 	"class" : {
 		"expect:toReturn:" : "TP 7/8/2019 22:41",
+		"expect:withArgument:toReturn:" : "TP 7/9/2019 10:57",
 		"expect:withArguments:toReturn:" : "TP 7/8/2019 22:41" },
 	"instance" : {
 		"doesNotUnderstand:" : "TP 7/9/2019 00:00",
 		"expect:toReturn:" : "TP 7/8/2019 22:41",
+		"expect:withArgument:toReturn:" : "TP 7/9/2019 10:55",
 		"expect:withArguments:toReturn:" : "TP 7/9/2019 00:58",
 		"expectations" : "TP 7/8/2019 22:14",
 		"expectations:" : "TP 7/8/2019 22:14",

--- a/packages/InteractiveProfilingTool-Tests.package/Mock.class/properties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/Mock.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "InteractiveProfilingTool-Tests",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		"expectations" ],
+	"name" : "Mock",
+	"pools" : [
+		 ],
+	"super" : "Object",
+	"type" : "normal" }

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/^equals.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/^equals.st
@@ -1,0 +1,6 @@
+comparing
+= anObject
+
+	^ self class == anObject class
+		and: (self selector == anObject selector)
+		and: (self arguments = anObject arguments)

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/arguments..st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/arguments..st
@@ -1,0 +1,4 @@
+accessing
+arguments: anObject
+
+	arguments := anObject

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/arguments.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/arguments.st
@@ -1,0 +1,4 @@
+accessing
+arguments
+
+	^ arguments

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/hash.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/hash.st
@@ -1,0 +1,9 @@
+comparing
+hash
+
+	| selector arguments |
+	
+	selector := { self selector }.
+	arguments := self arguments ifNil: {}.
+	
+	^ (selector, arguments) hash

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/matches..st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/matches..st
@@ -1,0 +1,4 @@
+accessing
+matches: aMessage
+
+	^ (self matchesSelector: aMessage selector) and: (self matchesArguments: aMessage arguments)

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/matchesArguments..st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/matchesArguments..st
@@ -1,0 +1,4 @@
+accessing
+matchesArguments: anArray
+
+	^ self arguments isNil or: (self arguments = anArray)

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/matchesSelector..st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/matchesSelector..st
@@ -1,0 +1,4 @@
+accessing
+matchesSelector: aSymbol
+
+	^ self selector == aSymbol

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/returnValue..st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/returnValue..st
@@ -1,0 +1,4 @@
+accessing
+returnValue: anObject
+
+	returnValue := anObject

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/returnValue.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/returnValue.st
@@ -1,0 +1,4 @@
+accessing
+returnValue
+
+	^ returnValue

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/selector..st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/selector..st
@@ -1,0 +1,4 @@
+accessing
+selector: anObject
+
+	selector := anObject

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/selector.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/instance/selector.st
@@ -1,0 +1,4 @@
+accessing
+selector
+
+	^ selector

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/methodProperties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/methodProperties.json
@@ -1,0 +1,14 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"=" : "TP 7/9/2019 00:53",
+		"arguments" : "TP 7/8/2019 22:29",
+		"arguments:" : "TP 7/8/2019 22:29",
+		"matches:" : "TP 7/8/2019 22:29",
+		"matchesArguments:" : "TP 7/9/2019 00:33",
+		"matchesSelector:" : "TP 7/8/2019 21:46",
+		"returnValue" : "TP 7/8/2019 22:29",
+		"returnValue:" : "TP 7/8/2019 22:29",
+		"selector" : "TP 7/8/2019 21:48",
+		"selector:" : "TP 7/8/2019 21:48" } }

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/methodProperties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/methodProperties.json
@@ -5,6 +5,7 @@
 		"=" : "TP 7/9/2019 00:53",
 		"arguments" : "TP 7/8/2019 22:29",
 		"arguments:" : "TP 7/8/2019 22:29",
+		"hash" : "TP 7/9/2019 15:41",
 		"matches:" : "TP 7/8/2019 22:29",
 		"matchesArguments:" : "TP 7/9/2019 00:33",
 		"matchesSelector:" : "TP 7/8/2019 21:46",

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/properties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectation.class/properties.json
@@ -1,0 +1,16 @@
+{
+	"category" : "InteractiveProfilingTool-Tests",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		"selector",
+		"returnValue",
+		"arguments" ],
+	"name" : "MockExpectation",
+	"pools" : [
+		 ],
+	"super" : "Object",
+	"type" : "normal" }

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEquals.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEquals.st
@@ -1,0 +1,16 @@
+tests
+testEquals
+
+	| expectation1 expectation2 |
+
+	expectation1 := MockExpectation new
+		selector: #sayHelloTo;
+		arguments: { 'Lothar Matthäus' };
+		yourself.
+		
+	expectation2 := MockExpectation new
+		selector: #sayHelloTo;
+		arguments: { 'Lothar Matthäus' };
+		yourself.
+		
+	self assert: expectation1 = expectation2.

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEquals.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEquals.st
@@ -14,3 +14,4 @@ testEquals
 		yourself.
 		
 	self assert: expectation1 = expectation2.
+	self assert: expectation1 hash == expectation2 hash

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentArguments.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentArguments.st
@@ -16,3 +16,4 @@ testEqualsWithDifferentArguments
 		yourself.
 		
 	self deny: expectation1 = expectation2.
+	self deny: expectation1 hash == expectation2 hash

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentArguments.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentArguments.st
@@ -1,0 +1,18 @@
+tests
+testEqualsWithDifferentArguments
+
+	| expectation1 expectation2 |
+
+	expectation1 := MockExpectation new
+		selector: #sayHelloTo:;
+		arguments: #(queen);
+		returnValue: 'Good morning, Your Majesty';
+		yourself.
+		
+	expectation2 := MockExpectation new
+		selector: #sayHelloTo:;
+		arguments: #(lothar);
+		returnValue: 'Moin Lothar, altes Haus!';
+		yourself.
+		
+	self deny: expectation1 = expectation2.

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentReturnValues.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentReturnValues.st
@@ -1,0 +1,18 @@
+tests
+testEqualsWithDifferentReturnValues
+
+	| expectation1 expectation2 |
+
+	expectation1 := MockExpectation new
+		selector: #sayHelloTo:;
+		arguments: { 'Lothar Matthäus' };
+		returnValue: 'Hallo Lothar!';
+		yourself.
+		
+	expectation2 := MockExpectation new
+		selector: #sayHelloTo:;
+		arguments: { 'Lothar Matthäus' };
+		returnValue: 'Moin Lothar!';
+		yourself.
+		
+	self assert: expectation1 = expectation2.

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentReturnValues.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentReturnValues.st
@@ -16,3 +16,4 @@ testEqualsWithDifferentReturnValues
 		yourself.
 		
 	self assert: expectation1 = expectation2.
+	self assert: expectation2 hash == expectation2 hash

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentSelectors.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentSelectors.st
@@ -1,0 +1,16 @@
+tests
+testEqualsWithDifferentSelectors
+
+	| expectation1 expectation2 |
+
+	expectation1 := MockExpectation new
+		selector: #greetTheQueen;
+		returnValue: 'Good morning, Your Majesty';
+		yourself.
+		
+	expectation2 := MockExpectation new
+		selector: #greetLothar;
+		returnValue: 'Na Lothar, alte Socke!';
+		yourself.
+		
+	self deny: expectation1 = expectation2.

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentSelectors.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithDifferentSelectors.st
@@ -14,3 +14,4 @@ testEqualsWithDifferentSelectors
 		yourself.
 		
 	self deny: expectation1 = expectation2.
+	self deny: expectation1 hash == expectation2 hash

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithoutArguments.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithoutArguments.st
@@ -12,3 +12,4 @@ testEqualsWithoutArguments
 		yourself.
 		
 	self assert: expectation1 = expectation2.
+	self assert: expectation1 hash == expectation2 hash

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithoutArguments.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testEqualsWithoutArguments.st
@@ -1,0 +1,14 @@
+tests
+testEqualsWithoutArguments
+
+	| expectation1 expectation2 |
+
+	expectation1 := MockExpectation new
+		selector: #sayHello;
+		yourself.
+		
+	expectation2 := MockExpectation new
+		selector: #sayHello;
+		yourself.
+		
+	self assert: expectation1 = expectation2.

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testMatchesArgumentsWithGivenArguments.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testMatchesArgumentsWithGivenArguments.st
@@ -1,0 +1,15 @@
+tests
+testMatchesArgumentsWithGivenArguments
+
+	| expectation message1 message2 |
+	
+	expectation := MockExpectation new
+		selector: #sayHelloTo:;
+		arguments: { #queen }
+		yourself.
+	
+	message1 := Message selector: #sayHelloTo: argument: #queen.
+	message2 := Message selector: #sayHelloTo: argument: #lothar.		
+
+	self assert: (expectation matchesArguments: message1 arguments).
+	self deny: (expectation matchesArguments: message2 arguments)

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testMatchesArgumentsWithoutGivenArguments.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testMatchesArgumentsWithoutGivenArguments.st
@@ -1,0 +1,14 @@
+tests
+testMatchesArgumentsWithoutGivenArguments
+
+	| expectation message1 message2 |
+
+	expectation := MockExpectation new
+		selector: #sayHelloTo:;
+		yourself.
+		
+	message1 := Message selector: #sayHelloTo: argument: #queen.
+	message2 := Message selector: #sayHelloTo: argument: #lothar.
+	
+	self assert: (expectation matchesArguments: message1).
+	self assert: (expectation matchesArguments: message2)

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testMatchesSelector.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/instance/testMatchesSelector.st
@@ -1,0 +1,14 @@
+tests
+testMatchesSelector
+
+	| expectation message1 message2 |
+
+	expectation := MockExpectation new
+		selector: #sayHello;
+		yourself.
+		
+	message1 := Message selector: #sayHello.
+	message2 := Message selector: #sayHelloTo: argument: #lothar.
+	
+	self assert: (expectation matchesSelector: message1 selector).
+	self deny: (expectation matchesSelector: message2 selector)

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/methodProperties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/methodProperties.json
@@ -2,11 +2,11 @@
 	"class" : {
 		 },
 	"instance" : {
-		"testEquals" : "TP 7/9/2019 00:16",
-		"testEqualsWithDifferentArguments" : "TP 7/9/2019 00:25",
-		"testEqualsWithDifferentReturnValues" : "TP 7/9/2019 00:24",
-		"testEqualsWithDifferentSelectors" : "TP 7/9/2019 00:37",
-		"testEqualsWithoutArguments" : "TP 7/9/2019 00:22",
+		"testEquals" : "TP 7/9/2019 15:52",
+		"testEqualsWithDifferentArguments" : "TP 7/9/2019 15:52",
+		"testEqualsWithDifferentReturnValues" : "TP 7/9/2019 15:52",
+		"testEqualsWithDifferentSelectors" : "TP 7/9/2019 15:52",
+		"testEqualsWithoutArguments" : "TP 7/9/2019 15:52",
 		"testMatchesArgumentsWithGivenArguments" : "TP 7/9/2019 00:32",
 		"testMatchesArgumentsWithoutGivenArguments" : "TP 7/9/2019 00:33",
 		"testMatchesSelector" : "TP 7/9/2019 00:35" } }

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/methodProperties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/methodProperties.json
@@ -1,0 +1,12 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"testEquals" : "TP 7/9/2019 00:16",
+		"testEqualsWithDifferentArguments" : "TP 7/9/2019 00:25",
+		"testEqualsWithDifferentReturnValues" : "TP 7/9/2019 00:24",
+		"testEqualsWithDifferentSelectors" : "TP 7/9/2019 00:37",
+		"testEqualsWithoutArguments" : "TP 7/9/2019 00:22",
+		"testMatchesArgumentsWithGivenArguments" : "TP 7/9/2019 00:32",
+		"testMatchesArgumentsWithoutGivenArguments" : "TP 7/9/2019 00:33",
+		"testMatchesSelector" : "TP 7/9/2019 00:35" } }

--- a/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/properties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/MockExpectionTestCase.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "InteractiveProfilingTool-Tests",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		 ],
+	"name" : "MockExpectionTestCase",
+	"pools" : [
+		 ],
+	"super" : "TestCase",
+	"type" : "normal" }

--- a/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/instance/testExpectToReturn.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/instance/testExpectToReturn.st
@@ -1,0 +1,10 @@
+tests
+testExpectToReturn
+
+	| mock |
+
+	mock := Mock new.
+	mock expect: #sayHello toReturn: 'Hello!'.
+	
+	self assert: 1 equals: mock expectations size.
+	self assert: 'Hello!' equals: mock expectations asArray first returnValue

--- a/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/instance/testWithDifferentArguments.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/instance/testWithDifferentArguments.st
@@ -1,0 +1,11 @@
+tests
+testWithDifferentArguments
+
+	| mock |
+
+	mock := Mock new.
+	mock expect: #sayHelloIn: withArguments: #(english) toReturn: 'Hello!'.
+	mock expect: #sayHelloIn: withArguments: #(french) toReturn: 'Bonjour!'.
+	
+	self assert: 'Hello!' equals: (mock sayHelloIn: #english).
+	self assert: 'Bonjour!' equals: (mock sayHelloIn: #french)

--- a/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/instance/testWithDifferentSelectors.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/instance/testWithDifferentSelectors.st
@@ -1,0 +1,11 @@
+tests
+testWithDifferentSelectors
+
+	| mock |
+
+	mock := Mock new.
+	mock expect: #sayHello toReturn: 'Hello!'.
+	mock expect: #sayBonjour toReturn: 'Bonjour!'.
+	
+	self assert: 'Hello!' equals: mock sayHello.
+	self assert: 'Bonjour!' equals: mock sayBonjour

--- a/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/instance/testWithEqualExpectations.st
+++ b/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/instance/testWithEqualExpectations.st
@@ -1,0 +1,11 @@
+tests
+testWithEqualExpectations
+
+	| mock |
+
+	mock := Mock new.
+	mock expect: #sayHello toReturn: 'Hello!'.
+	mock expect: #sayHello toReturn: 'Bonjour!'.
+	
+	self assert: 1 equals: mock expectations size.
+	self assert: 'Hello!' equals: mock sayHello

--- a/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/methodProperties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/methodProperties.json
@@ -1,0 +1,8 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"testExpectToReturn" : "TP 7/9/2019 00:43",
+		"testWithDifferentArguments" : "TP 7/9/2019 01:11",
+		"testWithDifferentSelectors" : "TP 7/9/2019 01:04",
+		"testWithEqualExpectations" : "TP 7/9/2019 01:06" } }

--- a/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/methodProperties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/methodProperties.json
@@ -5,4 +5,4 @@
 		"testExpectToReturn" : "TP 7/9/2019 00:43",
 		"testWithDifferentArguments" : "TP 7/9/2019 01:11",
 		"testWithDifferentSelectors" : "TP 7/9/2019 01:04",
-		"testWithEqualExpectations" : "TP 7/9/2019 01:06" } }
+		"testWithEqualExpectations" : "TP 7/9/2019 15:41" } }

--- a/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/properties.json
+++ b/packages/InteractiveProfilingTool-Tests.package/MockTestCase.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "InteractiveProfilingTool-Tests",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		 ],
+	"name" : "MockTestCase",
+	"pools" : [
+		 ],
+	"super" : "TestCase",
+	"type" : "normal" }


### PR DESCRIPTION
Hier ein vorschlag für eine einfache Mocking-Klasse. Schaut mal drüber – wenn’s euch passt würde ich das hier erstmal in den `master` mergen und dann Schritt für Schritt Tests in separaten PRs refactoren, wo notwendig.

Verwendung:
```smalltalk
mock := Mock expect: #helloWorld toReturn: 'Hello World!'.
mock helloWorld. "-> Hello World!"

mock expect: #sayHelloIn: withArgument: #english toReturn: 'Hello!'.
mock expect: #sayHelloIn: withArgument: #german toReturn: 'Hallo!'.
mock expect: #sayHelloIn: withArgument: #french toReturn: 'Bonjour!'.
mock sayHelloIn: #english. "-> 'Hello!'"
mock sayHelloIn: #german. "-> 'Hallo!'"
mock sayHelloIn: #french. "-> 'Bonjour!'"

mock expect: #add:to: withArguments: { 1 2 } toReturn: 3.
mock add: 1 to: 2. "-> 3".
```

Damit könnten z. B. [dieser](https://github.com/hpi-swa-teaching/InteractiveProfilingTool/blob/master/packages/InteractiveProfilingTool-Tests.package/IPTReportTestCase.class/instance/testGetIconIfAboveThreshold.st) und ähnliche Tests deutlich vereinfacht werden. Statt komplexe Fixtures zu initialisieren, kann einfach ein Mock verwendet werden…

Vorher:
```smalltalk
testgetIconIfAboveThreshold

	| model tallyMock wrappedTally expected actual |

	model := IPTReportMock new.

	tallyMock := MessageTallyMock new 
		method: Boolean >> #ifTrue:;
		tally: 70;
		receivers: {}.
		
	wrappedTally := MessageTallyWrapperMock new 
		messageTally: tallyMock;
		totalTallyCountOfOverallTree: 100;
		totalTimeOfOverallTree: 100;
		receivers: {}.

	expected := model class highRuntimeIcon bits.
	actual := (model getIcon: wrappedTally) bits.
	
	self assert: expected equals: actual
```

Nachher:
```smalltalk
testGetIconIfAboveThreshold

	| model wrapperMock expected actual |

	model := IPTReportMock new.
	wrapperMock := Mock expect: #hasHighRuntime toReturn: false.

	expected := model class highRuntimeIcon bits.
	actual := (model getIcon: wrapperMock) bits.

	self assert: expected equals: actual
```